### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+script:
+  - tox


### PR DESCRIPTION
I suggest to use Travis (or other) CI to run tests. If you agree with Travis, you might need to enable it at https://travis-ci.org/account/repositories.