### PR TITLE
Allow `set` and `save` to be chained

### DIFF
--- a/easysettings/common_base.py
+++ b/easysettings/common_base.py
@@ -259,6 +259,8 @@ class SettingsBase(UserDict):
         with BackedUpWriter(self.filename) as f:
             module.dump(self.save_hook(self.data), f, **kwargs)
 
+        return self
+
     def save_hook(self, data):
         """ Called on self.data before JSON encoding, before saving.
             Can be overridden to modify self.data before encoding/saving.
@@ -283,6 +285,7 @@ class SettingsBase(UserDict):
                 value   : Value to set for the option/key.
         """
         self.data[option] = value
+        return self
 
     def set_defaults(self, default_config):
         """ Save a copy of keys/value-types from `default_config` to optionally

--- a/easysettings/json_settings.py
+++ b/easysettings/json_settings.py
@@ -101,6 +101,8 @@ class JSONSettings(SettingsBase):
     def setsave(self, option, value, filename=None, sort_keys=False):
         """ The same as calling .set() and then .save(). """
         super(JSONSettings, self).setsave(
+            option,
+            value,
             filename=filename,
             sort_keys=sort_keys,
         )

--- a/easysettings/test_settingsbase.py
+++ b/easysettings/test_settingsbase.py
@@ -475,6 +475,25 @@ class SettingsBaseTests(object):
             msg='setattr() did not change the real attribute.',
         )
 
+    def test_chain_set_save(self):
+        """set() and save() can be chained"""
+        settings = self.settings_cls.from_file(self.testfile)
+        settings.set('option6', 'value6').save(filename=self.testfile)
+
+        with open(self.testfile) as f:
+            rawdata = f.read()
+
+        self.assertEqual(
+            settings.option6,
+            'value6',
+            msg='set().save() did not set the attribute.',
+        )
+
+        self.assertTrue(
+            ('option6' in rawdata) and ('value6' in rawdata),
+            msg='Could not find new option in saved data!',
+        )
+
 
 class JSONSettingsBaseTests(SettingsBaseTests):
     def test_encoder_decoder(self):

--- a/easysettings/test_settingsbase.py
+++ b/easysettings/test_settingsbase.py
@@ -475,6 +475,25 @@ class SettingsBaseTests(object):
             msg='setattr() did not change the real attribute.',
         )
 
+    def test_setsave(self):
+        """setsave() should work as a shortcut for set() and save()"""
+        settings = self.settings_cls.from_file(self.testfile)
+        settings.setsave('option5', 'value5', filename=self.testfile)
+
+        with open(self.testfile) as f:
+            rawdata = f.read()
+
+        self.assertEqual(
+            settings.option5,
+            'value5',
+            msg='setsave() did not set the attribute.',
+        )
+
+        self.assertTrue(
+            ('option5' in rawdata) and ('value5' in rawdata),
+            msg='Could not find new option in saved data!',
+        )
+
     def test_chain_set_save(self):
         """set() and save() can be chained"""
         settings = self.settings_cls.from_file(self.testfile)

--- a/easysettings/toml_settings.py
+++ b/easysettings/toml_settings.py
@@ -106,4 +106,4 @@ class TOMLSettings(SettingsBase):
 
     def setsave(self, option, value, filename=None):
         """ The same as calling .set() and then .save(). """
-        super(TOMLSettings, self).setsave(filename=filename)
+        super(TOMLSettings, self).setsave(option, value, filename=filename)

--- a/easysettings/yaml_settings.py
+++ b/easysettings/yaml_settings.py
@@ -101,4 +101,4 @@ class YAMLSettings(SettingsBase):
 
     def setsave(self, option, value, filename=None):
         """ The same as calling .set() and then .save(). """
-        super(YAMLSettings, self).setsave(filename=filename)
+        super(YAMLSettings, self).setsave(option, value, filename=filename)


### PR DESCRIPTION
Resolves #11 

## What I did

- [x] Modified the settings base class to `return self` on both `set()` and `save()`, allowing these two methods to be chained as an alternative to `setsave()`
- [x] Added a new test case to ensure that `set().save()` works as expected
- [x] Also, I added a new test case to the base settings tests to make the same check for `setsave()`
- [x] Fixed `setsave()` calls in `YAMLSettings` and `TOMLSettings`, as well as in `JSONSettings`, since they weren't passing the `option` and `value` arguments to the `super` call. This was uncovered after adding the test for `setsave` mentioned above.   

At this point I haven't removed the `setsave` method (in case it should remain for compatibility reasons), and I haven't (yet) made any changes to the README, changelog or docs, but I could do if needed!

## How to test

I added two new tests to `test_settingsbase`, all tests should pass with `pytest`